### PR TITLE
Feat: 검색어 디바운싱 및 페이지 이동

### DIFF
--- a/src/components/Describes/Describe.tsx
+++ b/src/components/Describes/Describe.tsx
@@ -34,10 +34,10 @@ export const Describe = ({info, idx}:Props) => {
             <DescDiv idx={idx} isDesc={info.img_src.includes('desc')}>
                 {info.main !== undefined && <MainTitle idx={idx}>{info.main}</MainTitle>}
                 <h2>
-                    {info.title.map(el => <>{el}<br/></>)}
+                    {info.title.map((el, idx:number) => <span key={idx}>{el}<br/></span>)}
                 </h2>
                 <div>
-                    {info.desc.map(el => <p>{el}</p>)}
+                    {info.desc.map((el, idx:number) => <p key={idx}>{el}</p>)}
                 </div>
             </DescDiv>
             <ImgDiv desc={info.img_src.includes('desc')}>

--- a/src/pages/Home/Components/FirstSection.tsx
+++ b/src/pages/Home/Components/FirstSection.tsx
@@ -32,7 +32,7 @@ export const FirstSection = () => {
 
     return (
         <SectionCotainer>
-            {info.map((el, idx) => <Describe info={el} idx={idx}></Describe>)}
+            {info.map((el, idx) => <Describe key={idx} info={el} idx={idx}></Describe>)}
         </SectionCotainer>
     )
 }

--- a/src/pages/Home/Components/SearchBar.tsx
+++ b/src/pages/Home/Components/SearchBar.tsx
@@ -1,30 +1,43 @@
 import styled from "styled-components"
 import { useState } from "react"
+import { useNavigate } from "react-router-dom"
 import axios from "axios"
+
+interface HouseInfo{
+    id:number;
+    address:string;
+}
 
 export const SearchBar = () => {
     const [address, setAddress] = useState<string>('')
     const [selectedTownData, setSelectedTownData] = useState<any>([])
     //일단 공공데이터로 Test
     const typeAddress = (e: any) => {
-        const apiUrl = 'https://api.home-predictor.com/apartments';
-        
-        axios.get(`${apiUrl}?address=${e.target.value}`, {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE'
-              }
-        })
+        const apiUrl = 'https://api.home-predictor.com/apartments'    
+        let timer
+        clearTimeout(timer)
+        timer = setTimeout(() => {
+            axios.get(`${apiUrl}?address=${e.target.value}`, {
+                headers: {
+                    'Access-Control-Allow-Origin': '*',
+                    'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE'
+                }
+            })
             .then(response => {
-                setSelectedTownData(response.data.slice(0, 10))
+                setSelectedTownData(response.data.slice(0, 20))
             })
             .catch(error => {
-                console.error('Error fetching data:', error);
-            });
+                console.error('Error fetching data:', error)
+            })
+        }, 500)
         setAddress(e.target.value)
     }
+    const navigate = useNavigate()
+    const showBuildingInfo = (id:number) => {
+        navigate(`/result/:${id}`)
+    }
     const boldMatchingSubstring = (str: string, substr: string) => {
-        const index = str.indexOf(substr);
+        const index = str.indexOf(substr)
         if (index !== -1) {
             return (
                 <span>
@@ -32,10 +45,10 @@ export const SearchBar = () => {
                     <HighLightSpan>{substr}</HighLightSpan>
                     {str.substring(index + substr.length)}
                 </span>
-            );
+            )
         }
-        return str;
-    };
+        return str
+    }
 
     return (
         <SearchBarContainer>
@@ -52,8 +65,8 @@ export const SearchBar = () => {
                 <SearchResultDiv>
                     {selectedTownData !== null && selectedTownData.length > 0 ? (
                         <ScrollDiv>
-                            {selectedTownData.map((el:any) => (
-                                <SearchResultContent>
+                            {selectedTownData.map((el:HouseInfo, idx:number) => (
+                                <SearchResultContent key={idx} onClick={() => showBuildingInfo(el.id)}>
                                     {boldMatchingSubstring(el.address, address)}
                                 </SearchResultContent>
                             ))}
@@ -186,6 +199,7 @@ const SearchResultContent = styled.div`
     }
     transition: color 0.25s ease;
     overflow:hidden;
+    cursor:pointer;
 `
 const NoResearchContent = styled(SearchResultContent)`
     &:hover{

--- a/src/pages/Home/Components/ThirdSection.tsx
+++ b/src/pages/Home/Components/ThirdSection.tsx
@@ -42,7 +42,7 @@ export const ThirdSection = () => {
 
     return (
         <SectionCotainer>
-            {info.map((el, idx) => <Describe info={el} idx={idx}></Describe>)}
+            {info.map((el, idx) => <Describe key={idx} info={el} idx={idx}></Describe>)}
         </SectionCotainer>
     )
 }


### PR DESCRIPTION
검색어 디바운싱 알고리즘 구현
검색 결과 클릭시 해당 빌딩 정보로 이동

## #️⃣연관된 이슈

> Feat#12

## 📝작업 내용

> 백엔드 API 연동
> 검색어 디바운싱
> 해당 id의 건물 정보로 이동
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 디바운싱 및 데이터 이동 잘 되는지 확인해 주시면 감사하겠습니다!
> 상세 스타일링 및 결과 페이지에서 제가 담당 할 부분도 배분해 주세요 :)
